### PR TITLE
fix: namespace and auto-exit

### DIFF
--- a/split-yaml
+++ b/split-yaml
@@ -22,7 +22,10 @@ def extract(fname, doc):
     if not os.path.isdir(of):
         os.mkdir(of, 0o0755)
     ver = re.sub('/', '-', doc['apiVersion'])
-    ofname = os.path.join(of, f"{ver}-{doc['kind']}-{doc['metadata']['namespace']}-{doc['metadata']['name']}.yaml")
+    if 'namespace' in doc['metadata']:
+        ofname = os.path.join(of, f"{ver}-{doc['kind']}-{doc['metadata']['namespace']}-{doc['metadata']['name']}.yaml")
+    else:
+        ofname = os.path.join(of, f"{ver}-{doc['kind']}-{doc['metadata']['name']}.yaml")
     with open(ofname, 'w') as stream:
         print("---", file=stream)
         print(yaml.safe_dump(doc, default_flow_style=False), file=stream)
@@ -34,6 +37,4 @@ for fname in sys.argv[1:]:
                 extract(fname, doc)
         except yaml.YAMLError as exc:
             print(f"Error parsing input {fname} :: {exc}", file=sys.stderr)
-            sys.exit(1)
-        finally:
             sys.exit(1)


### PR DESCRIPTION
- Let unexpected errors go to the console. Better to diagnose/etc.
- Fix a problem where non-namespaced resources would barf